### PR TITLE
Adding Laravel 5 Support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "license": "MIT License",
     "require": {
-        "php": ">=5.3.0",
-        "illuminate/support": "4.x"
+        "php": ">=5.4.0",
+        "illuminate/support": "5.*"
     },
     "require-dev":{
         "way/laravel-test-helpers": "dev-master",
-        "symfony/dom-crawler": "~2.0",
-        "symfony/css-selector": "~2.0",
-        "phpunit/phpunit": "~4.4"
+        "symfony/dom-crawler": "~2.*",
+        "symfony/css-selector": "~2.*",
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "license": "MIT License",
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/support": "5.*"
+        "php": ">=5.3.0",
+        "illuminate/support": "4.*|5.*"
     },
     "require-dev":{
         "way/laravel-test-helpers": "dev-master",
-        "symfony/dom-crawler": "~2.*",
-        "symfony/css-selector": "~2.*",
-        "phpunit/phpunit": "~4.0"
+        "symfony/dom-crawler": "~2.0",
+        "symfony/css-selector": "~2.0",
+        "phpunit/phpunit": "~4.4"
     },
     "autoload": {
         "psr-0": {

--- a/src/Creitive/Breadcrumbs/BreadcrumbsServiceProvider.php
+++ b/src/Creitive/Breadcrumbs/BreadcrumbsServiceProvider.php
@@ -1,6 +1,8 @@
 <?php namespace Creitive\Breadcrumbs;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class BreadcrumbsServiceProvider extends ServiceProvider {
 
@@ -11,7 +13,14 @@ class BreadcrumbsServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('creitive/breadcrumbs');
+        if ($this->isLegacyLaravel() || $this->isOldLaravel())
+        {
+		    $this->package('creitive/breadcrumbs');
+        }
+
+        $loader = \Illuminate\Foundation\AliasLoader::getInstance();
+        $loader->alias('Breadcrumbs', 'Creitive\Breadcrumbs\Facades\Breadcrumbs');
+
 	}
 
 	/**
@@ -21,12 +30,21 @@ class BreadcrumbsServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
+
 		$this->app['breadcrumbs'] = $this->app->share(function($app)
 		{
 			return new Breadcrumbs;
 		});
-
-		$this->app->alias('breadcrumbs', 'Creitive\Breadcrumbs\Breadcrumbs');
 	}
+
+    public function isLegacyLaravel()
+    {
+      return Str::startsWith(Application::VERSION, array('4.1.', '4.2.'));
+    }
+
+    public function isOldLaravel()
+    {
+        return Str::startsWith(Application::VERSION, '4.0.');
+    }
 
 }


### PR DESCRIPTION
You don't have to add below this lines, beacause they have already added in `BreadcrumbsServiceProvider` class.
```
 'aliases' => array(
        // ...

        'Breadcrumbs' => 'Creitive\Breadcrumbs\Facades\Breadcrumbs',
    ),
```

Laravel 5 uses namespaces in controllers. Pleased use as `\Breadcrumbs::MethodName`